### PR TITLE
Fix supabase imports and typos

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,6 @@
 const config = {
   plugins: ["@tailwindcss/postcss"],
-  darkmode: 'class',
+  darkMode: "class",
   content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},

--- a/src/components/EssayReview.jsx
+++ b/src/components/EssayReview.jsx
@@ -1,6 +1,6 @@
 "use client"
 import React, { useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "../utils/supabase/client";
 
 export default function EssayReview() {
   const [essay, setEssay] = useState("");

--- a/src/components/GenerateTimeline.jsx
+++ b/src/components/GenerateTimeline.jsx
@@ -1,6 +1,6 @@
 "use client"
 import React, { useState, useEffect } from 'react'
-import { supabase } from '../lib/supabaseClient'
+import { supabase } from "../utils/supabase/client";
 
 export default function GenerateTimeline() {
   const [userData, setUserData] = useState(null)

--- a/src/components/Onboarding.jsx
+++ b/src/components/Onboarding.jsx
@@ -34,9 +34,9 @@ export default function Onboarding() {
       goals: formData.goals,
     };
 
-    console.log("Submiting onboarding", mappedFormData, "User ID", user.id);
+    console.log("Submitting onboarding", mappedFormData, "User ID", user.id);
     const { error } = await supabase.from("users").upsert([mappedFormData]);
-    console.log("Submiting onboarding", mappedFormData, "User ID", user.id);
+    console.log("Submitting onboarding", mappedFormData, "User ID", user.id);
 
     if (error) {
       console.error("Insert error:", error.message);

--- a/src/components/UpdatePassword.jsx
+++ b/src/components/UpdatePassword.jsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "../utils/supabase/client";
 import { useRouter } from "next/navigation"
 
 export default function UpdatePassword() {


### PR DESCRIPTION
## Summary
- fix incorrect Supabase import paths
- correct typo in onboarding logs
- use `darkMode` option in PostCSS config

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb19cb90832f93d4a7c80e149dad